### PR TITLE
feat(stats): add lifetime earnings tracking for daily, weekly, work, and rob

### DIFF
--- a/commands/economy/money.h
+++ b/commands/economy/money.h
@@ -43,6 +43,7 @@ inline ::std::vector<Command*> get_money_commands(Database* db) {
             // Cooldown claimed - now give the reward
             if (db->update_wallet(event.msg.author.id, amount)) {
                 log_balance_change(db, event.msg.author.id, "claimed daily reward +$" + format_number(amount));
+                db->increment_stat(event.msg.author.id, "daily_earnings_total", amount);
                 ::commands::pets::pet_hooks::on_daily(db, event.msg.author.id);
                 ::commands::daily_challenges::track_daily_stat(db, event.msg.author.id, "coins_earned_today", amount);
                 
@@ -75,6 +76,7 @@ inline ::std::vector<Command*> get_money_commands(Database* db) {
             // Cooldown claimed - now give the reward
             if (db->update_wallet(event.command.get_issuing_user().id, amount)) {
                 log_balance_change(db, event.command.get_issuing_user().id, "claimed daily reward +$" + format_number(amount));
+                db->increment_stat(event.command.get_issuing_user().id, "daily_earnings_total", amount);
                 ::commands::pets::pet_hooks::on_daily(db, event.command.get_issuing_user().id);
                 ::commands::daily_challenges::track_daily_stat(db, event.command.get_issuing_user().id, "coins_earned_today", amount);
                 
@@ -111,7 +113,7 @@ inline ::std::vector<Command*> get_money_commands(Database* db) {
             // Cooldown claimed - now give the reward
             if (db->update_wallet(event.msg.author.id, amount)) {
                 log_balance_change(db, event.msg.author.id, "claimed weekly reward +$" + format_number(amount));
-                
+                db->increment_stat(event.msg.author.id, "weekly_earnings_total", amount);
                 auto embed = bronx::success("claimed your weekly reward of $" + format_number(amount) + "!\n(50% of your networth: $" + format_number(networth) + ")");
                 bronx::add_invoker_footer(embed, event.msg.author);
                 bronx::send_message(bot, event, embed);
@@ -141,7 +143,7 @@ inline ::std::vector<Command*> get_money_commands(Database* db) {
             // Cooldown claimed - now give the reward
             if (db->update_wallet(event.command.get_issuing_user().id, amount)) {
                 log_balance_change(db, event.command.get_issuing_user().id, "claimed weekly reward +$" + format_number(amount));
-                
+                db->increment_stat(event.command.get_issuing_user().id, "weekly_earnings_total", amount);
                 auto embed = bronx::success("claimed your weekly reward of $" + format_number(amount) + "!\n(50% of your networth: $" + format_number(networth) + ")");
                 bronx::add_invoker_footer(embed, event.command.get_issuing_user());
                 event.reply(dpp::message().add_embed(embed));
@@ -191,6 +193,7 @@ inline ::std::vector<Command*> get_money_commands(Database* db) {
             // Cooldown claimed - now give the reward
             if (db->update_wallet(event.msg.author.id, amount)) {
                 log_balance_change(db, event.msg.author.id, "worked (" + job + ") +$" + format_number(amount));
+                db->increment_stat(event.msg.author.id, "work_earnings_total", amount);
                 ::commands::pets::pet_hooks::on_work(db, event.msg.author.id);
                 ::commands::daily_challenges::track_daily_stat(db, event.msg.author.id, "work_count_today", 1);
                 ::commands::daily_challenges::track_daily_stat(db, event.msg.author.id, "coins_earned_today", amount);
@@ -242,6 +245,7 @@ inline ::std::vector<Command*> get_money_commands(Database* db) {
             // Cooldown claimed - now give the reward
             if (db->update_wallet(event.command.get_issuing_user().id, amount)) {
                 log_balance_change(db, event.command.get_issuing_user().id, "worked (" + job + ") +$" + format_number(amount));
+                db->increment_stat(event.command.get_issuing_user().id, "work_earnings_total", amount);
                 ::commands::pets::pet_hooks::on_work(db, event.command.get_issuing_user().id);
                 ::commands::daily_challenges::track_daily_stat(db, event.command.get_issuing_user().id, "work_count_today", 1);
                 ::commands::daily_challenges::track_daily_stat(db, event.command.get_issuing_user().id, "coins_earned_today", amount);

--- a/commands/economy/rob.h
+++ b/commands/economy/rob.h
@@ -256,10 +256,11 @@ inline ::std::vector<Command*> get_rob_commands(Database* db) {
                     db->set_cooldown(robber_id, "rob", 7200); // 2 hour cooldown
                     log_balance_change(db, robber_id, "robbed " + victim_username + " for $" + format_number(stolen_amount));
                     log_balance_change(db, victim_id, "was robbed by <@" + ::std::to_string(robber_id) + "> for $" + format_number(stolen_amount));
-                    
+                    db->increment_stat(robber_id, "rob_earnings_total", stolen_amount);
+
                     ::std::string description = "💰 **robbery successful!**\n";
                     description += "you stole $" + format_number(stolen_amount) + " from " + victim_username + "!";
-                    
+
                     auto embed = bronx::success(description);
                     bronx::add_invoker_footer(embed, event.msg.author);
                     bronx::send_message(bot, event, embed);
@@ -414,10 +415,11 @@ inline ::std::vector<Command*> get_rob_commands(Database* db) {
                     db->set_cooldown(robber_id, "rob", 7200); // 2 hour cooldown
                     log_balance_change(db, robber_id, "robbed " + victim_username + " for $" + format_number(stolen_amount));
                     log_balance_change(db, victim_id, "was robbed by <@" + ::std::to_string(robber_id) + "> for $" + format_number(stolen_amount));
-                    
+                    db->increment_stat(robber_id, "rob_earnings_total", stolen_amount);
+
                     ::std::string description = "💰 **robbery successful!**\n";
                     description += "you stole $" + format_number(stolen_amount) + " from " + victim_username + "!";
-                    
+
                     auto embed = bronx::success(description);
                     bronx::add_invoker_footer(embed, event.command.get_issuing_user());
                     event.reply(dpp::message().add_embed(embed));


### PR DESCRIPTION
## Summary
- `daily_earnings_total` — tracked on every successful daily claim (text + slash)
- `weekly_earnings_total` — tracked on every weekly claim (text + slash)
- `work_earnings_total` — tracked on every work payout (text + slash)
- `rob_earnings_total` — tracked on every successful rob (text + slash)
- All writes go to `user_stats_ext` via `db->increment_stat`, consistent with existing stat pattern

## Test plan
- [ ] Compile bot with `./deploy_bot.sh` to verify no syntax errors
- [ ] Run `.daily`, `.work`, `.weekly`, `.rob` and confirm new stat keys appear in `user_stats_ext`

🤖 Generated with [Claude Code](https://claude.com/claude-code)